### PR TITLE
Fix mailer in development

### DIFF
--- a/MYR_rails/Gemfile
+++ b/MYR_rails/Gemfile
@@ -62,6 +62,8 @@ group :development, :test do
   #gem 'web-console', '~> 2.0'
 end
 
+gem "letter_opener", group: :development
+
 group :test do
   gem 'minitest-reporters', '1.0.5'
   gem 'mini_backtrace',     '0.1.3'

--- a/MYR_rails/Gemfile.lock
+++ b/MYR_rails/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
     arel (6.0.4)
     autoprefixer-rails (8.2.0)
@@ -92,6 +94,10 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.6.0)
+      launchy (~> 2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -128,6 +134,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (3.0.2)
     rack (1.6.9)
     rack-ssl (1.4.1)
       rack
@@ -210,6 +217,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-cookie-rails
   jquery-rails
+  letter_opener
   mini_backtrace (= 0.1.3)
   mini_magick
   minitest-reporters (= 1.0.5)

--- a/MYR_rails/config/environments/development.rb
+++ b/MYR_rails/config/environments/development.rb
@@ -38,26 +38,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  
+
   config.action_mailer.raise_delivery_errors = true
-
-  # SMTP settings for gmail
   config.action_mailer.default_url_options = { :host => "localhost:3000" }
-  config.action_mailer.delivery_method = :smtp
-	config.action_mailer.smtp_settings = {
-	 address:               "smtp.gmail.com",
-	 port:                  587,
-	 user_name:             "wrscroot@gmail.com",
-	 password:              "wrscAdmin2015",
-	 authentication:        "plain",
-	 enable_starttls_auto:  true
-	}
-
-  #   address:              'smtp.gmail.com',
-#    port:                 587,
-#    user_name:            'enstabmons@gmail.com',
-#    password:             'enstabmons2015',
-#    authentication:       'plain',
-#    enable_starttls_auto: true 
-
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 end


### PR DESCRIPTION
When you sign up locally in development mode, the app would attempt to send emails via Gmail:

<img width="922" alt="screen shot 2018-04-15 at 15 34 56" src="https://user-images.githubusercontent.com/522155/38782531-fec1f124-40c2-11e8-8115-c1522ef7921f.png">

We shouldn't do that in development. Instead there's a `letter_opener` library that opens the email locally in the browser.

@takluyver 