### PR TITLE
Latest coordinates endpoint

### DIFF
--- a/MYR_rails/app/controllers/coordinates_controller.rb
+++ b/MYR_rails/app/controllers/coordinates_controller.rb
@@ -73,6 +73,25 @@ class CoordinatesController < ApplicationController
     end
   end
 
+  def index_by_mission
+    mission = Mission.find(params[:id])
+
+    latest_coordinates = mission.attempts.map do |attempt|
+      [attempt, attempt.coordinates.order(datetime: :desc).first]
+    end.select do |attempt, coordinate|
+      coordinate
+    end.map do |attempt, coordinate|
+      coordinate.as_json(only: [:id, :datetime, :latitude, :longitude, :tracker_id]).merge(
+        "robot_id" => attempt.robot.id,
+        "robot_name" => attempt.robot.name,
+        "team_id" => attempt.robot.team.id,
+        "team_name" => attempt.robot.team.name,
+      )
+    end
+
+    render json: latest_coordinates
+  end
+
   # GET /coordinates/1
   # GET /coordinates/1.json
   def show

--- a/MYR_rails/app/models/coordinate.rb
+++ b/MYR_rails/app/models/coordinate.rb
@@ -20,5 +20,8 @@ class Coordinate < ActiveRecord::Base
 	  	end
 	end
 
+  def datetime_as_time
+    Time.strptime("#{datetime}UTC",'%Y%m%d%H%M%S%z')
+  end
 end
 

--- a/MYR_rails/config/routes.rb
+++ b/MYR_rails/config/routes.rb
@@ -22,7 +22,13 @@ Rails.application.routes.draw do
     end
     resources :robots
     resources :attempts
-    resources :missions
+
+  resources :missions do
+    member do
+      get :coordinates, to: "coordinates#index_by_mission"
+    end
+  end
+
     resources :markers
     resources :sessions
     resources :scores

--- a/MYR_rails/config/routes.rb
+++ b/MYR_rails/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
 
   resources :missions do
     member do
-      get :coordinates, to: "coordinates#index_by_mission"
+      get :latest_coordinates, to: "coordinates#latest_by_mission"
     end
   end
 

--- a/MYR_rails/test/controllers/coordinates_controller_test.rb
+++ b/MYR_rails/test/controllers/coordinates_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class CoordinatesControllerTest < ActionController::TestCase
   setup do
-    @tracker = trackers(:mytracker)
+    @tracker = trackers(:testotron_tracker)
     @coordinate = coordinates(:c1)
   end
 
@@ -49,10 +49,35 @@ class CoordinatesControllerTest < ActionController::TestCase
     assert_response :created
   end
 
-
   test "should show coordinate" do
     get :show, id: @coordinate
     assert_response :success
+  end
+
+  test "#index_by_mission" do
+    mission = missions(:triangularRace)
+    datetime = 5.minutes.from_now.strftime("%Y%m%d%H%M%S")
+
+    mission.attempts.each do |attempt|
+      Coordinate.create!(
+        tracker: attempt.tracker,
+        datetime: datetime,
+        longitude: 1,
+        latitude: 2,
+        speed: 1,
+      )
+    end
+
+    get :index_by_mission, id: mission.id
+
+    parsed_response = JSON.parse(response.body)
+    assert_equal 2, parsed_response.size
+
+    expected_keys = %w(id tracker_id datetime latitude
+      longitude robot_id robot_name team_id team_name)
+    assert_equal expected_keys, parsed_response.first.keys
+
+    assert_equal [datetime, datetime], parsed_response.map { |c| c["datetime"] }
   end
 
 =begin

--- a/MYR_rails/test/controllers/coordinates_controller_test.rb
+++ b/MYR_rails/test/controllers/coordinates_controller_test.rb
@@ -54,30 +54,32 @@ class CoordinatesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "#index_by_mission" do
+  test "#latest_by_mission" do
     mission = missions(:triangularRace)
-    datetime = 5.minutes.from_now.strftime("%Y%m%d%H%M%S")
+    datetime = 5.minutes.from_now
 
     mission.attempts.each do |attempt|
       Coordinate.create!(
         tracker: attempt.tracker,
-        datetime: datetime,
+        datetime: datetime.strftime("%Y%m%d%H%M%S"),
         longitude: 1,
         latitude: 2,
         speed: 1,
       )
     end
 
-    get :index_by_mission, id: mission.id
+    get :latest_by_mission, id: mission.id
 
     parsed_response = JSON.parse(response.body)
     assert_equal 2, parsed_response.size
 
-    expected_keys = %w(id tracker_id datetime latitude
-      longitude robot_id robot_name team_id team_name)
-    assert_equal expected_keys, parsed_response.first.keys
+    tracker_keys = %w(tracker_id robot_id robot_name team_name latest_coordinates)
+    assert_equal tracker_keys, parsed_response.first.keys
 
-    assert_equal [datetime, datetime], parsed_response.map { |c| c["datetime"] }
+    coordinate_keys = %w(latitude longitude datetime)
+    assert_equal coordinate_keys, parsed_response.first["latest_coordinates"][0].keys
+
+    assert_equal [datetime.iso8601, datetime.iso8601], parsed_response.map { |c| c.dig("latest_coordinates", 0, "datetime") }
   end
 
 =begin

--- a/MYR_rails/test/fixtures/attempts.yml
+++ b/MYR_rails/test/fixtures/attempts.yml
@@ -1,20 +1,28 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 myTriangle:
-    name: myTriangle
-    start: 2015-06-05 01:01:00
-    end: 2015-09-01 00:00:00
-    robot_id: 1
-    mission_id: 1
-    tracker_id: 4
+  name: myTriangle
+  start: 2015-06-05 01:01:00
+  end: 2015-09-01 00:00:00
+  robot: testotron
+  mission_id: 1
+  tracker: testotron_tracker
 
 myRace:
-    name: myRace
-    start: 2015-06-05 01:01:00
-    end: 2015-09-01 00:00:00
-    robot_id: 1
-    mission_id: 3
-    tracker_id: 2
+  name: myRace
+  start: 2015-06-05 01:01:00
+  end: 2015-09-01 00:00:00
+  robot: testotron
+  mission_id: 3
+  tracker: testotron_tracker
+
+myRace2:
+  name: myRace2
+  start: 2015-06-05 01:01:00
+  end: 2015-09-01 00:00:00
+  robot: snowball
+  mission_id: 3
+  tracker: snowball_tracker
 
 #one:
 #  name: MyString

--- a/MYR_rails/test/fixtures/coordinates.yml
+++ b/MYR_rails/test/fixtures/coordinates.yml
@@ -13,6 +13,12 @@
 #  datetime: 2015-02-25 15:39:26
 #  tracker_id: 1
 
+snowball_coordinate_1:
+  latitude: 5
+  longitude: 2
+  datetime: '20150225153927'
+  tracker: snowball_tracker
+
 #coordinates for testing the triangular course scoring function
 
 <% t = 20150605010101 %>
@@ -22,7 +28,7 @@ c1:
     datetime: <%= t %>
     speed: 1
     course: 1
-    tracker_id: 4
+    tracker: testotron_tracker
 
 <% t = CoordinatesFixtureHelper.increment_time(t.to_s, 5) %>
 
@@ -32,7 +38,7 @@ c2:
     datetime: <%= t %>
     speed: 1
     course: 1
-    tracker_id: 4
+    tracker: testotron_tracker
 
 <% t = CoordinatesFixtureHelper.increment_time(t.to_s, 5) %>
 
@@ -50,7 +56,7 @@ c<%=n+3%>:
     datetime: <%= t %>
     speed: 1
     course: 1
-    tracker_id: 4
+    tracker: testotron_tracker
 
 
 <% t = CoordinatesFixtureHelper.increment_time(t.to_s, 5) %>
@@ -72,7 +78,7 @@ c<%=n+53%>:
     datetime: <%= t %>
     speed: 1
     course: 1
-    tracker_id: 4
+    tracker: testotron_tracker
 
 
 <% t = CoordinatesFixtureHelper.increment_time(t.to_s, 5) %>
@@ -86,7 +92,7 @@ c108:
     datetime: <%= t %>
     speed: 1
     course: 1
-    tracker_id: 4
+    tracker: testotron_tracker
 
 # coordinates for testing the race course scoring function
 

--- a/MYR_rails/test/fixtures/missions.yml
+++ b/MYR_rails/test/fixtures/missions.yml
@@ -1,22 +1,14 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 triangularRace:
-    name: triangularRace
-    start: 2015-06-01 00:00:00
-    end: 2015-09-01 00:00:00
-    id: 1
+  name: triangularRace
+  start: 2015-06-01 00:00:00
+  end: 2015-09-01 00:00:00
+  id: 1
 
 triangularRace:
-    name: triangularRace
-    start: 2015-06-01 00:00:00
-    end: 2015-09-01 00:00:00
-    id: 3
-    startOfRace: 20150605010100
-
-#one:
-#  name: MyString
-#  description: MyText
-
-#two:
-#  name: MyString
-#  description: MyText
+  name: triangularRace
+  start: 2015-06-01 00:00:00
+  end: 2015-09-01 00:00:00
+  id: 3
+  startOfRace: 20150605010100

--- a/MYR_rails/test/fixtures/robots.yml
+++ b/MYR_rails/test/fixtures/robots.yml
@@ -1,15 +1,11 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 testotron:
-    name: testotron
-    category: MicroSailboat
-    team_id: 1
-#one:
-#  name: MyString
-#  category: MyString
-#  team_id: 1
+  name: testotron
+  category: MicroSailboat
+  team: sylvain
 
-#two:
-#  name: MyString
-#  category: MyString
-#  team_id: 1
+snowball:
+  name: snowball
+  category: MicroSailboat
+  team: senators

--- a/MYR_rails/test/fixtures/teams.yml
+++ b/MYR_rails/test/fixtures/teams.yml
@@ -1,7 +1,10 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-SylvainTeam:
-    name: SylvainTeam
+sylvain:
+  name: SylvainTeam
+
+senators:
+  name: senators
 
 #one:
 #  name: MyString

--- a/MYR_rails/test/fixtures/trackers.yml
+++ b/MYR_rails/test/fixtures/trackers.yml
@@ -1,14 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-mytracker:
-    token: 1234
-    id: 1
+testotron_tracker:
+  token: 1234
+  description: testotron
 
-#one:
-#  token: MyString
-#  description: 1
-
-#two:
-#  token: MyString
-#  description: 1
-
+snowball_tracker:
+  token: 1234
+  description: snowball


### PR DESCRIPTION
As discussed in https://github.com/WRSC/tracking/issues/3#issuecomment-385264413

Example of the response:

```json
[
  {
    "id": 1071896132,
    "tracker_id": 824207793,
    "datetime": "20180501104904",
    "latitude": "2",
    "longitude": "1",
    "robot_id": 995256502,
    "robot_name": "snowball",
    "team_id": 990681772,
    "team_name": "senators"
  },
  {
    "id": 1071896133,
    "tracker_id": 409766844,
    "datetime": "20180501104904",
    "latitude": "2",
    "longitude": "1",
    "robot_id": 1046216088,
    "robot_name": "testotron",
    "team_id": 695669099,
    "team_name": "SylvainTeam"
  }
]
```